### PR TITLE
Update references to JQuery 3.3.1

### DIFF
--- a/resources/EdgarWorkstationSummarize.xslt
+++ b/resources/EdgarWorkstationSummarize.xslt
@@ -3,7 +3,7 @@
      Herm Fischer, Mark V Systems Limited, 2015-08-30
      Requires parameter "accessionNumber"
      sec.gov files are part of tomcat workstation's web content of include & Images directory
-        include/jquery-1.4.3.min.js
+        include/jquery-3.3.1.min.js
         include/accordionMenu.js
         include/Show.js
         include/interactive.css
@@ -124,7 +124,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta http-equiv="Cache-Control" content="no-cache"/>
         <title>View Filing Data</title>
-        <script type="text/javascript" src="include/jquery-1.4.3.min.js"/>
+        <script type="text/javascript" src="include/jquery-3.3.1.min.js"/>
         <script type="text/javascript" src="include/accordionMenu.js"/>
         <script type="text/javascript" src="include/Show.js"/>
         <link rel="stylesheet" type="text/css" href="include/interactive.css"/>

--- a/resources/Summarize.xslt
+++ b/resources/Summarize.xslt
@@ -64,7 +64,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta http-equiv="Cache-Control" content="no-cache"/>
         <title>View Filing Data</title>
-        <script type="text/javascript" src="/include/jquery-1.4.3.min.js"/>
+        <script type="text/javascript" src="/include/jquery-3.3.1.min.js"/>
         <script type="text/javascript" src="/include/accordionMenu.js"/>
         <script type="text/javascript" src="/include/Show.js"/>
         <link rel="stylesheet" type="text/css" href="/include/interactive.css"/>


### PR DESCRIPTION
This is a second part of the "libraries update" code change for SEC viewers, and it completes the change.